### PR TITLE
Implement OpenMetrics specification

### DIFF
--- a/core/include/prometheus/client_metric.h
+++ b/core/include/prometheus/client_metric.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <string>
 #include <tuple>
@@ -77,7 +78,7 @@ struct PROMETHEUS_CPP_CORE_EXPORT ClientMetric {
 
   // Timestamp
 
-  std::int64_t timestamp_ms = 0;
+  std::chrono::milliseconds timestamp{std::chrono::seconds::zero()};
 };
 
 }  // namespace prometheus

--- a/core/include/prometheus/serializer.h
+++ b/core/include/prometheus/serializer.h
@@ -12,7 +12,7 @@ namespace prometheus {
 class PROMETHEUS_CPP_CORE_EXPORT Serializer {
  public:
   virtual ~Serializer() = default;
-  virtual std::string Serialize(const std::vector<MetricFamily>&) const;
+  virtual std::string Serialize(const std::vector<MetricFamily>& metrics) const;
   virtual void Serialize(std::ostream& out,
                          const std::vector<MetricFamily>& metrics) const = 0;
 };

--- a/core/include/prometheus/text_serializer.h
+++ b/core/include/prometheus/text_serializer.h
@@ -12,8 +12,12 @@ namespace prometheus {
 class PROMETHEUS_CPP_CORE_EXPORT TextSerializer : public Serializer {
  public:
   using Serializer::Serialize;
+  std::string Serialize(const std::vector<MetricFamily>& metrics,
+                        bool open_metrics) const;
   void Serialize(std::ostream& out,
                  const std::vector<MetricFamily>& metrics) const override;
+  void Serialize(std::ostream& out, const std::vector<MetricFamily>& metrics,
+                 bool open_metrics) const;
 };
 
 }  // namespace prometheus

--- a/core/include/prometheus/text_serializer.h
+++ b/core/include/prometheus/text_serializer.h
@@ -12,12 +12,8 @@ namespace prometheus {
 class PROMETHEUS_CPP_CORE_EXPORT TextSerializer : public Serializer {
  public:
   using Serializer::Serialize;
-  std::string Serialize(const std::vector<MetricFamily>& metrics,
-                        bool open_metrics) const;
   void Serialize(std::ostream& out,
                  const std::vector<MetricFamily>& metrics) const override;
-  void Serialize(std::ostream& out, const std::vector<MetricFamily>& metrics,
-                 bool open_metrics) const;
 };
 
 }  // namespace prometheus

--- a/core/src/text_serializer.cc
+++ b/core/src/text_serializer.cc
@@ -1,5 +1,6 @@
 #include "prometheus/text_serializer.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <limits>
@@ -76,87 +77,81 @@ void WriteHead(std::ostream& out, const MetricFamily& family,
 }
 
 // Write a line trailer: timestamp
-void WriteTail(std::ostream& out, const ClientMetric& metric,
-               const bool open_metrics) {
+void WriteTail(std::ostream& out, const ClientMetric& metric) {
   if (metric.timestamp != std::chrono::seconds::zero()) {
-    out << " ";
-    if (open_metrics) {
-      using FloatSeconds = std::chrono::duration<double>;
-      out << std::chrono::duration_cast<FloatSeconds>(metric.timestamp).count();
-    } else {
-      out << metric.timestamp.count();
-    }
+    using FloatSeconds = std::chrono::duration<double>;
+    out << " "
+        << std::chrono::duration_cast<FloatSeconds>(metric.timestamp).count();
   }
   out << "\n";
 }
 
 void SerializeCounter(std::ostream& out, const MetricFamily& family,
-                      const ClientMetric& metric, const bool open_metrics) {
+                      const ClientMetric& metric) {
   WriteHead(out, family, metric, "_total");
   WriteValue(out, metric.counter.value);
-  WriteTail(out, metric, open_metrics);
+  WriteTail(out, metric);
 }
 
 void SerializeGauge(std::ostream& out, const MetricFamily& family,
-                    const ClientMetric& metric, const bool open_metrics) {
+                    const ClientMetric& metric) {
   WriteHead(out, family, metric);
   WriteValue(out, metric.gauge.value);
-  WriteTail(out, metric, open_metrics);
+  WriteTail(out, metric);
 }
 
 void SerializeSummary(std::ostream& out, const MetricFamily& family,
-                      const ClientMetric& metric, const bool open_metrics) {
+                      const ClientMetric& metric) {
   auto& sum = metric.summary;
   WriteHead(out, family, metric, "_count");
   out << sum.sample_count;
-  WriteTail(out, metric, open_metrics);
+  WriteTail(out, metric);
 
   WriteHead(out, family, metric, "_sum");
   WriteValue(out, sum.sample_sum);
-  WriteTail(out, metric, open_metrics);
+  WriteTail(out, metric);
 
   for (auto& q : sum.quantile) {
     WriteHead(out, family, metric, "", "quantile", q.quantile);
     WriteValue(out, q.value);
-    WriteTail(out, metric, open_metrics);
+    WriteTail(out, metric);
   }
 }
 
 void SerializeUntyped(std::ostream& out, const MetricFamily& family,
-                      const ClientMetric& metric, const bool open_metrics) {
+                      const ClientMetric& metric) {
   WriteHead(out, family, metric);
   WriteValue(out, metric.untyped.value);
-  WriteTail(out, metric, open_metrics);
+  WriteTail(out, metric);
 }
 
 void SerializeHistogram(std::ostream& out, const MetricFamily& family,
-                        const ClientMetric& metric, const bool open_metrics) {
+                        const ClientMetric& metric) {
   auto& hist = metric.histogram;
   WriteHead(out, family, metric, "_count");
   out << hist.sample_count;
-  WriteTail(out, metric, open_metrics);
+  WriteTail(out, metric);
 
   WriteHead(out, family, metric, "_sum");
   WriteValue(out, hist.sample_sum);
-  WriteTail(out, metric, open_metrics);
+  WriteTail(out, metric);
 
   double last = -std::numeric_limits<double>::infinity();
   for (auto& b : hist.bucket) {
     WriteHead(out, family, metric, "_bucket", "le", b.upper_bound);
     last = b.upper_bound;
     out << b.cumulative_count;
-    WriteTail(out, metric, open_metrics);
+    WriteTail(out, metric);
   }
 
   if (last != std::numeric_limits<double>::infinity()) {
     WriteHead(out, family, metric, "_bucket", "le", "+Inf");
     out << hist.sample_count;
-    WriteTail(out, metric, open_metrics);
+    WriteTail(out, metric);
   }
 }
 
-void SerializeFamily(std::ostream& out, const MetricFamily& family,
-                     const bool open_metrics) {
+void SerializeFamily(std::ostream& out, const MetricFamily& family) {
   const auto ends_with = [](const std::string& value,
                             const std::string& ending) -> bool {
     if (ending.size() > value.size()) {
@@ -181,90 +176,52 @@ void SerializeFamily(std::ostream& out, const MetricFamily& family,
   std::stable_sort(sorted_family.metric.begin(), sorted_family.metric.end(),
                    compare_metrics);
 
+  if (sorted_family.type == MetricType::Counter) {
+    remove_suffix(sorted_family.name, "_total");
+  }
+
+  if (!sorted_family.help.empty()) {
+    out << "# HELP " << sorted_family.name << " " << sorted_family.help << "\n";
+  }
+
   switch (sorted_family.type) {
     case MetricType::Counter: {
-      remove_suffix(sorted_family.name, "_total");
-      out << "# TYPE " << sorted_family.name;
-      if (!open_metrics) {
-        out << "_total";
-      }
-      out << " counter\n";
-      if (!sorted_family.help.empty()) {
-        out << "# HELP " << sorted_family.name;
-        if (!open_metrics) {
-          out << "_total";
-        }
-        out << " " << sorted_family.help << "\n";
-      }
+      out << "# TYPE " << sorted_family.name << " counter\n";
       for (const auto& metric : sorted_family.metric) {
-        SerializeCounter(out, sorted_family, metric, open_metrics);
+        SerializeCounter(out, sorted_family, metric);
       }
       break;
     }
     case MetricType::Gauge:
       out << "# TYPE " << sorted_family.name << " gauge\n";
-      if (!sorted_family.help.empty()) {
-        out << "# HELP " << sorted_family.name << " " << sorted_family.help
-            << "\n";
-      }
       for (auto& metric : sorted_family.metric) {
-        SerializeGauge(out, sorted_family, metric, open_metrics);
+        SerializeGauge(out, sorted_family, metric);
       }
       break;
     case MetricType::Summary:
       out << "# TYPE " << sorted_family.name << " summary\n";
-      if (!sorted_family.help.empty()) {
-        out << "# HELP " << sorted_family.name << " " << sorted_family.help
-            << "\n";
-      }
       for (auto& metric : sorted_family.metric) {
-        SerializeSummary(out, sorted_family, metric, open_metrics);
+        SerializeSummary(out, sorted_family, metric);
       }
       break;
     case MetricType::Untyped:
-      out << "# TYPE " << sorted_family.name;
-      if (open_metrics) {
-        out << " unknown\n";
-      } else {
-        out << " untyped\n";
-      }
-      if (!sorted_family.help.empty()) {
-        out << "# HELP " << sorted_family.name << " " << sorted_family.help
-            << "\n";
-      }
+      out << "# TYPE " << sorted_family.name << " unknown\n";
       for (auto& metric : sorted_family.metric) {
-        SerializeUntyped(out, sorted_family, metric, open_metrics);
+        SerializeUntyped(out, sorted_family, metric);
       }
       break;
     case MetricType::Histogram:
       out << "# TYPE " << sorted_family.name << " histogram\n";
-      if (!sorted_family.help.empty()) {
-        out << "# HELP " << sorted_family.name << " " << sorted_family.help
-            << "\n";
-      }
       for (auto& metric : sorted_family.metric) {
-        SerializeHistogram(out, sorted_family, metric, open_metrics);
+        SerializeHistogram(out, sorted_family, metric);
       }
       break;
   }
 }
 }  // namespace
 
-std::string TextSerializer::Serialize(const std::vector<MetricFamily>& metrics,
-                                      const bool open_metrics) const {
-  std::ostringstream ss;
-  Serialize(ss, metrics, open_metrics);
-  return ss.str();
-}
-
 void TextSerializer::Serialize(std::ostream& out,
                                const std::vector<MetricFamily>& metrics) const {
-  Serialize(out, metrics, false);
-}
-
-void TextSerializer::Serialize(std::ostream& out,
-                               const std::vector<MetricFamily>& metrics,
-                               const bool open_metrics) const {
   auto saved_locale = out.getloc();
   auto saved_precision = out.precision();
 
@@ -272,14 +229,13 @@ void TextSerializer::Serialize(std::ostream& out,
   out.precision(std::numeric_limits<double>::max_digits10 - 1);
 
   for (auto& family : metrics) {
-    SerializeFamily(out, family, open_metrics);
+    SerializeFamily(out, family);
   }
 
-  if (open_metrics) {
-    out << "# EOF\n";
-  }
+  out << "# EOF\n";
 
   out.imbue(saved_locale);
   out.precision(saved_precision);
 }
+
 }  // namespace prometheus

--- a/core/src/text_serializer.cc
+++ b/core/src/text_serializer.cc
@@ -1,5 +1,6 @@
 #include "prometheus/text_serializer.h"
 
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <locale>
@@ -75,119 +76,195 @@ void WriteHead(std::ostream& out, const MetricFamily& family,
 }
 
 // Write a line trailer: timestamp
-void WriteTail(std::ostream& out, const ClientMetric& metric) {
-  if (metric.timestamp_ms != 0) {
-    out << " " << metric.timestamp_ms;
+void WriteTail(std::ostream& out, const ClientMetric& metric,
+               const bool open_metrics) {
+  if (metric.timestamp != std::chrono::seconds::zero()) {
+    out << " ";
+    if (open_metrics) {
+      using FloatSeconds = std::chrono::duration<double>;
+      out << std::chrono::duration_cast<FloatSeconds>(metric.timestamp).count();
+    } else {
+      out << metric.timestamp.count();
+    }
   }
   out << "\n";
 }
 
 void SerializeCounter(std::ostream& out, const MetricFamily& family,
-                      const ClientMetric& metric) {
-  WriteHead(out, family, metric);
+                      const ClientMetric& metric, const bool open_metrics) {
+  WriteHead(out, family, metric, "_total");
   WriteValue(out, metric.counter.value);
-  WriteTail(out, metric);
+  WriteTail(out, metric, open_metrics);
 }
 
 void SerializeGauge(std::ostream& out, const MetricFamily& family,
-                    const ClientMetric& metric) {
+                    const ClientMetric& metric, const bool open_metrics) {
   WriteHead(out, family, metric);
   WriteValue(out, metric.gauge.value);
-  WriteTail(out, metric);
+  WriteTail(out, metric, open_metrics);
 }
 
 void SerializeSummary(std::ostream& out, const MetricFamily& family,
-                      const ClientMetric& metric) {
+                      const ClientMetric& metric, const bool open_metrics) {
   auto& sum = metric.summary;
   WriteHead(out, family, metric, "_count");
   out << sum.sample_count;
-  WriteTail(out, metric);
+  WriteTail(out, metric, open_metrics);
 
   WriteHead(out, family, metric, "_sum");
   WriteValue(out, sum.sample_sum);
-  WriteTail(out, metric);
+  WriteTail(out, metric, open_metrics);
 
   for (auto& q : sum.quantile) {
     WriteHead(out, family, metric, "", "quantile", q.quantile);
     WriteValue(out, q.value);
-    WriteTail(out, metric);
+    WriteTail(out, metric, open_metrics);
   }
 }
 
 void SerializeUntyped(std::ostream& out, const MetricFamily& family,
-                      const ClientMetric& metric) {
+                      const ClientMetric& metric, const bool open_metrics) {
   WriteHead(out, family, metric);
   WriteValue(out, metric.untyped.value);
-  WriteTail(out, metric);
+  WriteTail(out, metric, open_metrics);
 }
 
 void SerializeHistogram(std::ostream& out, const MetricFamily& family,
-                        const ClientMetric& metric) {
+                        const ClientMetric& metric, const bool open_metrics) {
   auto& hist = metric.histogram;
   WriteHead(out, family, metric, "_count");
   out << hist.sample_count;
-  WriteTail(out, metric);
+  WriteTail(out, metric, open_metrics);
 
   WriteHead(out, family, metric, "_sum");
   WriteValue(out, hist.sample_sum);
-  WriteTail(out, metric);
+  WriteTail(out, metric, open_metrics);
 
   double last = -std::numeric_limits<double>::infinity();
   for (auto& b : hist.bucket) {
     WriteHead(out, family, metric, "_bucket", "le", b.upper_bound);
     last = b.upper_bound;
     out << b.cumulative_count;
-    WriteTail(out, metric);
+    WriteTail(out, metric, open_metrics);
   }
 
   if (last != std::numeric_limits<double>::infinity()) {
     WriteHead(out, family, metric, "_bucket", "le", "+Inf");
     out << hist.sample_count;
-    WriteTail(out, metric);
+    WriteTail(out, metric, open_metrics);
   }
 }
 
-void SerializeFamily(std::ostream& out, const MetricFamily& family) {
-  if (!family.help.empty()) {
-    out << "# HELP " << family.name << " " << family.help << "\n";
-  }
-  switch (family.type) {
-    case MetricType::Counter:
-      out << "# TYPE " << family.name << " counter\n";
-      for (auto& metric : family.metric) {
-        SerializeCounter(out, family, metric);
+void SerializeFamily(std::ostream& out, const MetricFamily& family,
+                     const bool open_metrics) {
+  const auto ends_with = [](const std::string& value,
+                            const std::string& ending) -> bool {
+    if (ending.size() > value.size()) {
+      return false;
+    }
+    return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+  };
+
+  const auto remove_suffix = [&ends_with](std::string& value,
+                                          const std::string& suffix) {
+    if (ends_with(value, suffix)) {
+      value.erase(value.end() - suffix.size(), value.end());
+    }
+  };
+
+  const auto compare_metrics = [](const ClientMetric& a,
+                                  const ClientMetric& b) {
+    return std::tie(a.label, a.timestamp) < std::tie(b.label, b.timestamp);
+  };
+
+  MetricFamily sorted_family{family};
+  std::stable_sort(sorted_family.metric.begin(), sorted_family.metric.end(),
+                   compare_metrics);
+
+  switch (sorted_family.type) {
+    case MetricType::Counter: {
+      remove_suffix(sorted_family.name, "_total");
+      out << "# TYPE " << sorted_family.name;
+      if (!open_metrics) {
+        out << "_total";
+      }
+      out << " counter\n";
+      if (!sorted_family.help.empty()) {
+        out << "# HELP " << sorted_family.name;
+        if (!open_metrics) {
+          out << "_total";
+        }
+        out << " " << sorted_family.help << "\n";
+      }
+      for (const auto& metric : sorted_family.metric) {
+        SerializeCounter(out, sorted_family, metric, open_metrics);
       }
       break;
+    }
     case MetricType::Gauge:
-      out << "# TYPE " << family.name << " gauge\n";
-      for (auto& metric : family.metric) {
-        SerializeGauge(out, family, metric);
+      out << "# TYPE " << sorted_family.name << " gauge\n";
+      if (!sorted_family.help.empty()) {
+        out << "# HELP " << sorted_family.name << " " << sorted_family.help
+            << "\n";
+      }
+      for (auto& metric : sorted_family.metric) {
+        SerializeGauge(out, sorted_family, metric, open_metrics);
       }
       break;
     case MetricType::Summary:
-      out << "# TYPE " << family.name << " summary\n";
-      for (auto& metric : family.metric) {
-        SerializeSummary(out, family, metric);
+      out << "# TYPE " << sorted_family.name << " summary\n";
+      if (!sorted_family.help.empty()) {
+        out << "# HELP " << sorted_family.name << " " << sorted_family.help
+            << "\n";
+      }
+      for (auto& metric : sorted_family.metric) {
+        SerializeSummary(out, sorted_family, metric, open_metrics);
       }
       break;
     case MetricType::Untyped:
-      out << "# TYPE " << family.name << " untyped\n";
-      for (auto& metric : family.metric) {
-        SerializeUntyped(out, family, metric);
+      out << "# TYPE " << sorted_family.name;
+      if (open_metrics) {
+        out << " unknown\n";
+      } else {
+        out << " untyped\n";
+      }
+      if (!sorted_family.help.empty()) {
+        out << "# HELP " << sorted_family.name << " " << sorted_family.help
+            << "\n";
+      }
+      for (auto& metric : sorted_family.metric) {
+        SerializeUntyped(out, sorted_family, metric, open_metrics);
       }
       break;
     case MetricType::Histogram:
-      out << "# TYPE " << family.name << " histogram\n";
-      for (auto& metric : family.metric) {
-        SerializeHistogram(out, family, metric);
+      out << "# TYPE " << sorted_family.name << " histogram\n";
+      if (!sorted_family.help.empty()) {
+        out << "# HELP " << sorted_family.name << " " << sorted_family.help
+            << "\n";
+      }
+      for (auto& metric : sorted_family.metric) {
+        SerializeHistogram(out, sorted_family, metric, open_metrics);
       }
       break;
   }
 }
 }  // namespace
 
+std::string TextSerializer::Serialize(const std::vector<MetricFamily>& metrics,
+                                      const bool open_metrics) const {
+  std::ostringstream ss;
+  Serialize(ss, metrics, open_metrics);
+  return ss.str();
+}
+
 void TextSerializer::Serialize(std::ostream& out,
                                const std::vector<MetricFamily>& metrics) const {
+  Serialize(out, metrics, false);
+}
+
+void TextSerializer::Serialize(std::ostream& out,
+                               const std::vector<MetricFamily>& metrics,
+                               const bool open_metrics) const {
   auto saved_locale = out.getloc();
   auto saved_precision = out.precision();
 
@@ -195,7 +272,11 @@ void TextSerializer::Serialize(std::ostream& out,
   out.precision(std::numeric_limits<double>::max_digits10 - 1);
 
   for (auto& family : metrics) {
-    SerializeFamily(out, family);
+    SerializeFamily(out, family, open_metrics);
+  }
+
+  if (open_metrics) {
+    out << "# EOF\n";
   }
 
   out.imbue(saved_locale);

--- a/core/tests/text_serializer_test.cc
+++ b/core/tests/text_serializer_test.cc
@@ -31,18 +31,6 @@ class TextSerializerTest : public testing::Test {
     return textSerializer.Serialize(families);
   }
 
-  std::string Serialize(MetricType type, bool open_metrics) const {
-    MetricFamily metricFamily;
-    metricFamily.name = name;
-    metricFamily.help = help;
-    metricFamily.type = type;
-    metricFamily.metric = std::vector<ClientMetric>{metric};
-
-    std::vector<MetricFamily> families{metricFamily};
-
-    return textSerializer.Serialize(families, open_metrics);
-  }
-
   std::string name = "my_metric";
   std::string help = "my metric help text";
   ClientMetric metric;
@@ -111,16 +99,6 @@ TEST_F(TextSerializerTest, shouldSerializeUntyped) {
   metric.untyped.value = 64.0;
 
   const auto serialized = Serialize(MetricType::Untyped);
-  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " untyped\n"));
-  EXPECT_THAT(serialized,
-              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
-  EXPECT_THAT(serialized, testing::HasSubstr(name + " 64\n"));
-}
-
-TEST_F(TextSerializerTest, shouldSerializeOpenMetricsUntyped) {
-  metric.untyped.value = 64.0;
-
-  const auto serialized = Serialize(MetricType::Untyped, true);
   EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " unknown\n"));
   EXPECT_THAT(serialized,
               testing::HasSubstr("# HELP " + name + " " + help + "\n"));
@@ -132,17 +110,6 @@ TEST_F(TextSerializerTest, shouldSerializeTimestamp) {
   metric.timestamp = std::chrono::milliseconds(1234);
 
   const auto serialized = Serialize(MetricType::Gauge);
-  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " gauge\n"));
-  EXPECT_THAT(serialized,
-              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
-  EXPECT_THAT(serialized, testing::HasSubstr(name + " 64 1234\n"));
-}
-
-TEST_F(TextSerializerTest, shouldSerializeOpenMetricsTimestamp) {
-  metric.gauge.value = 64.0;
-  metric.timestamp = std::chrono::milliseconds(1234);
-
-  const auto serialized = Serialize(MetricType::Gauge, true);
   EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " gauge\n"));
   EXPECT_THAT(serialized,
               testing::HasSubstr("# HELP " + name + " " + help + "\n"));
@@ -201,10 +168,9 @@ TEST_F(TextSerializerTest, shouldSerializeCounter) {
   metric.counter.value = 1.0;
 
   const auto serialized = Serialize(MetricType::Counter);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " counter\n"));
   EXPECT_THAT(serialized,
-              testing::HasSubstr("# TYPE " + name + "_total counter\n"));
-  EXPECT_THAT(serialized,
-              testing::HasSubstr("# HELP " + name + "_total " + help + "\n"));
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + "_total 1\n"));
 }
 
@@ -214,29 +180,6 @@ TEST_F(TextSerializerTest, shouldSerializeCounterWithSuffix) {
   metric.counter.value = 1.0;
 
   const auto serialized = Serialize(MetricType::Counter);
-  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + original_name +
-                                             "_total counter\n"));
-  EXPECT_THAT(serialized, testing::HasSubstr("# HELP " + original_name +
-                                             "_total " + help + "\n"));
-  EXPECT_THAT(serialized, testing::HasSubstr(original_name + "_total 1\n"));
-}
-
-TEST_F(TextSerializerTest, shouldSerializeOpenMetricsCounter) {
-  metric.counter.value = 1.0;
-
-  const auto serialized = Serialize(MetricType::Counter, true);
-  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " counter\n"));
-  EXPECT_THAT(serialized,
-              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
-  EXPECT_THAT(serialized, testing::HasSubstr(name + "_total 1\n"));
-}
-
-TEST_F(TextSerializerTest, shouldSerializeOpenMetricsCounterWithSuffix) {
-  const std::string original_name = name;
-  name += "_total";
-  metric.counter.value = 1.0;
-
-  const auto serialized = Serialize(MetricType::Counter, true);
   EXPECT_THAT(serialized,
               testing::HasSubstr("# TYPE " + original_name + " counter\n"));
   EXPECT_THAT(serialized, testing::HasSubstr("# HELP " + original_name + " " +
@@ -248,12 +191,12 @@ TEST_F(TextSerializerTest, shouldSerializeNoHelp) {
   help.clear();
 
   EXPECT_THAT(
-      Serialize(MetricType::Gauge, true),
+      Serialize(MetricType::Gauge),
       testing::Not(testing::HasSubstr("# HELP " + name + " " + help + "\n")));
 }
 
-TEST_F(TextSerializerTest, shouldSerializeOpenMetricsEof) {
-  EXPECT_THAT(Serialize(MetricType::Gauge, true), testing::EndsWith("# EOF\n"));
+TEST_F(TextSerializerTest, shouldSerializeEof) {
+  EXPECT_THAT(Serialize(MetricType::Gauge), testing::EndsWith("# EOF\n"));
 }
 
 TEST_F(TextSerializerTest, shouldSortLabels) {
@@ -274,29 +217,29 @@ TEST_F(TextSerializerTest, shouldSortLabels) {
   std::vector<MetricFamily> families{metricFamily};
 
   const auto serialized = textSerializer.Serialize(families);
-  EXPECT_THAT(serialized, testing::EndsWith(name + "{b=\"bb\"} 1\n"));
+  EXPECT_THAT(serialized, testing::EndsWith(name + "{b=\"bb\"} 1\n# EOF\n"));
 }
 
 TEST_F(TextSerializerTest, shouldSortLabelsAndTime) {
   ClientMetric metric1;
   metric1.label.emplace_back(ClientMetric::Label{"b", "bb"});
   metric1.gauge.value = 2;
-  metric1.timestamp = std::chrono::milliseconds(200);
+  metric1.timestamp = std::chrono::milliseconds(2000);
 
   ClientMetric metric2;
   metric2.label.emplace_back(ClientMetric::Label{"a", "aa"});
   metric2.gauge.value = 2;
-  metric2.timestamp = std::chrono::milliseconds(200);
+  metric2.timestamp = std::chrono::milliseconds(2000);
 
   ClientMetric metric3;
   metric3.label.emplace_back(ClientMetric::Label{"b", "bb"});
   metric3.gauge.value = 1;
-  metric3.timestamp = std::chrono::milliseconds(100);
+  metric3.timestamp = std::chrono::milliseconds(1000);
 
   ClientMetric metric4;
   metric4.label.emplace_back(ClientMetric::Label{"a", "aa"});
   metric4.gauge.value = 1;
-  metric4.timestamp = std::chrono::milliseconds(100);
+  metric4.timestamp = std::chrono::milliseconds(1000);
 
   MetricFamily metricFamily;
   metricFamily.name = name;
@@ -308,8 +251,8 @@ TEST_F(TextSerializerTest, shouldSortLabelsAndTime) {
   std::vector<MetricFamily> families{metricFamily};
 
   const auto serialized = textSerializer.Serialize(families);
-  EXPECT_THAT(serialized, testing::EndsWith(name + "{b=\"bb\"} 1 100\n" + name +
-                                            "{b=\"bb\"} 2 200\n"));
+  EXPECT_THAT(serialized, testing::EndsWith(name + "{b=\"bb\"} 1 1\n" + name +
+                                            "{b=\"bb\"} 2 2\n# EOF\n"));
 }
 
 }  // namespace

--- a/core/tests/text_serializer_test.cc
+++ b/core/tests/text_serializer_test.cc
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <string>
@@ -21,7 +22,7 @@ class TextSerializerTest : public testing::Test {
   std::string Serialize(MetricType type) const {
     MetricFamily metricFamily;
     metricFamily.name = name;
-    metricFamily.help = "my metric help text";
+    metricFamily.help = help;
     metricFamily.type = type;
     metricFamily.metric = std::vector<ClientMetric>{metric};
 
@@ -30,24 +31,62 @@ class TextSerializerTest : public testing::Test {
     return textSerializer.Serialize(families);
   }
 
-  const std::string name = "my_metric";
+  std::string Serialize(MetricType type, bool open_metrics) const {
+    MetricFamily metricFamily;
+    metricFamily.name = name;
+    metricFamily.help = help;
+    metricFamily.type = type;
+    metricFamily.metric = std::vector<ClientMetric>{metric};
+
+    std::vector<MetricFamily> families{metricFamily};
+
+    return textSerializer.Serialize(families, open_metrics);
+  }
+
+  std::string name = "my_metric";
+  std::string help = "my metric help text";
   ClientMetric metric;
   TextSerializer textSerializer;
 };
 
+TEST_F(TextSerializerTest, shouldSerializeGauge) {
+  metric.gauge.value = 12.3;
+
+  const auto serialized = Serialize(MetricType::Gauge);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " gauge\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + " 12.3"));
+}
+
 TEST_F(TextSerializerTest, shouldSerializeNotANumber) {
   metric.gauge.value = std::nan("");
-  EXPECT_THAT(Serialize(MetricType::Gauge), testing::HasSubstr(name + " Nan"));
+
+  const auto serialized = Serialize(MetricType::Gauge);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " gauge\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + " Nan"));
 }
 
 TEST_F(TextSerializerTest, shouldSerializeNegativeInfinity) {
   metric.gauge.value = -std::numeric_limits<double>::infinity();
-  EXPECT_THAT(Serialize(MetricType::Gauge), testing::HasSubstr(name + " -Inf"));
+
+  const auto serialized = Serialize(MetricType::Gauge);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " gauge\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + " -Inf"));
 }
 
 TEST_F(TextSerializerTest, shouldSerializePositiveInfinity) {
   metric.gauge.value = std::numeric_limits<double>::infinity();
-  EXPECT_THAT(Serialize(MetricType::Gauge), testing::HasSubstr(name + " +Inf"));
+
+  const auto serialized = Serialize(MetricType::Gauge);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " gauge\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + " +Inf"));
 }
 
 TEST_F(TextSerializerTest, shouldEscapeBackslash) {
@@ -72,15 +111,42 @@ TEST_F(TextSerializerTest, shouldSerializeUntyped) {
   metric.untyped.value = 64.0;
 
   const auto serialized = Serialize(MetricType::Untyped);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " untyped\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + " 64\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeOpenMetricsUntyped) {
+  metric.untyped.value = 64.0;
+
+  const auto serialized = Serialize(MetricType::Untyped, true);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " unknown\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + " 64\n"));
 }
 
 TEST_F(TextSerializerTest, shouldSerializeTimestamp) {
-  metric.counter.value = 64.0;
-  metric.timestamp_ms = 1234;
+  metric.gauge.value = 64.0;
+  metric.timestamp = std::chrono::milliseconds(1234);
 
-  const auto serialized = Serialize(MetricType::Counter);
+  const auto serialized = Serialize(MetricType::Gauge);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " gauge\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + " 64 1234\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeOpenMetricsTimestamp) {
+  metric.gauge.value = 64.0;
+  metric.timestamp = std::chrono::milliseconds(1234);
+
+  const auto serialized = Serialize(MetricType::Gauge, true);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " gauge\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + " 64 1.234\n"));
 }
 
 TEST_F(TextSerializerTest, shouldSerializeHistogramWithNoBuckets) {
@@ -88,7 +154,11 @@ TEST_F(TextSerializerTest, shouldSerializeHistogramWithNoBuckets) {
   metric.histogram.sample_sum = 32.0;
 
   const auto serialized = Serialize(MetricType::Histogram);
-  EXPECT_THAT(serialized, testing::HasSubstr(name + "_count 2"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# TYPE " + name + " histogram\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + "_count 2\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + "_sum 32\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + "_bucket{le=\"+Inf\"} 2"));
 }
@@ -100,6 +170,10 @@ TEST_F(TextSerializerTest, shouldSerializeHistogram) {
   metric = histogram.Collect();
 
   const auto serialized = Serialize(MetricType::Histogram);
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# TYPE " + name + " histogram\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + "_count 2\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + "_sum 200\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + "_bucket{le=\"1\"} 1\n"));
@@ -114,9 +188,128 @@ TEST_F(TextSerializerTest, shouldSerializeSummary) {
   metric = summary.Collect();
 
   const auto serialized = Serialize(MetricType::Summary);
-  EXPECT_THAT(serialized, testing::HasSubstr(name + "_count 2"));
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " summary\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + "_count 2\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + "_sum 200\n"));
   EXPECT_THAT(serialized, testing::HasSubstr(name + "{quantile=\"0.5\"} 0\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeCounter) {
+  name = "short";
+  metric.counter.value = 1.0;
+
+  const auto serialized = Serialize(MetricType::Counter);
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# TYPE " + name + "_total counter\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + "_total " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + "_total 1\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeCounterWithSuffix) {
+  const std::string original_name = name;
+  name += "_total";
+  metric.counter.value = 1.0;
+
+  const auto serialized = Serialize(MetricType::Counter);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + original_name +
+                                             "_total counter\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr("# HELP " + original_name +
+                                             "_total " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(original_name + "_total 1\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeOpenMetricsCounter) {
+  metric.counter.value = 1.0;
+
+  const auto serialized = Serialize(MetricType::Counter, true);
+  EXPECT_THAT(serialized, testing::HasSubstr("# TYPE " + name + " counter\n"));
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# HELP " + name + " " + help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(name + "_total 1\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeOpenMetricsCounterWithSuffix) {
+  const std::string original_name = name;
+  name += "_total";
+  metric.counter.value = 1.0;
+
+  const auto serialized = Serialize(MetricType::Counter, true);
+  EXPECT_THAT(serialized,
+              testing::HasSubstr("# TYPE " + original_name + " counter\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr("# HELP " + original_name + " " +
+                                             help + "\n"));
+  EXPECT_THAT(serialized, testing::HasSubstr(original_name + "_total 1\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeNoHelp) {
+  help.clear();
+
+  EXPECT_THAT(
+      Serialize(MetricType::Gauge, true),
+      testing::Not(testing::HasSubstr("# HELP " + name + " " + help + "\n")));
+}
+
+TEST_F(TextSerializerTest, shouldSerializeOpenMetricsEof) {
+  EXPECT_THAT(Serialize(MetricType::Gauge, true), testing::EndsWith("# EOF\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSortLabels) {
+  ClientMetric metric1;
+  metric1.label.emplace_back(ClientMetric::Label{"b", "bb"});
+  metric1.gauge.value = 1;
+
+  ClientMetric metric2;
+  metric2.label.emplace_back(ClientMetric::Label{"a", "aa"});
+  metric2.gauge.value = 1;
+
+  MetricFamily metricFamily;
+  metricFamily.name = name;
+  metricFamily.help = help;
+  metricFamily.type = MetricType::Gauge;
+  metricFamily.metric = std::vector<ClientMetric>{metric1, metric2};
+
+  std::vector<MetricFamily> families{metricFamily};
+
+  const auto serialized = textSerializer.Serialize(families);
+  EXPECT_THAT(serialized, testing::EndsWith(name + "{b=\"bb\"} 1\n"));
+}
+
+TEST_F(TextSerializerTest, shouldSortLabelsAndTime) {
+  ClientMetric metric1;
+  metric1.label.emplace_back(ClientMetric::Label{"b", "bb"});
+  metric1.gauge.value = 2;
+  metric1.timestamp = std::chrono::milliseconds(200);
+
+  ClientMetric metric2;
+  metric2.label.emplace_back(ClientMetric::Label{"a", "aa"});
+  metric2.gauge.value = 2;
+  metric2.timestamp = std::chrono::milliseconds(200);
+
+  ClientMetric metric3;
+  metric3.label.emplace_back(ClientMetric::Label{"b", "bb"});
+  metric3.gauge.value = 1;
+  metric3.timestamp = std::chrono::milliseconds(100);
+
+  ClientMetric metric4;
+  metric4.label.emplace_back(ClientMetric::Label{"a", "aa"});
+  metric4.gauge.value = 1;
+  metric4.timestamp = std::chrono::milliseconds(100);
+
+  MetricFamily metricFamily;
+  metricFamily.name = name;
+  metricFamily.help = help;
+  metricFamily.type = MetricType::Gauge;
+  metricFamily.metric =
+      std::vector<ClientMetric>{metric1, metric2, metric3, metric4};
+
+  std::vector<MetricFamily> families{metricFamily};
+
+  const auto serialized = textSerializer.Serialize(families);
+  EXPECT_THAT(serialized, testing::EndsWith(name + "{b=\"bb\"} 1 100\n" + name +
+                                            "{b=\"bb\"} 2 200\n"));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR is set to merge on the rebased master, but I will update that once https://github.com/swift-nav/prometheus-cpp/pull/7 is merged.

The [OpenMetrics specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md) has a few changes from the previous [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format).

This PR adds a flag to allow enabling the OpenMetrics format. Which changes the following:
- `# EOF` is added to the end
- the `untyped` metric type is now called `unknown`
- for `counter` metrics the value name must now end in `_total` (which was the recommended practice with Prometheus prior).
- for `counter` metrics the name in the `# TYPE` header must not contain `_total`
- timestamps are now floating point numbers with units of seconds instead of integers with units of milliseconds

I have added a bunch of tests to check the changes.