### PR TITLE
Add Bazel 9 compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "boringssl", version = "0.0.0-20240530-2db0eb3")
-bazel_dep(name = "civetweb", version = "1.16.bcr.3")
+bazel_dep(name = "civetweb", version = "1.16.bcr.4")
 bazel_dep(name = "curl", version = "7.82.0.swiftnav", repo_name = "com_github_curl")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:export_header.bzl", "generate_dummy_export_header")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 generate_dummy_export_header(
     name = "export_header",

--- a/pull/BUILD.bazel
+++ b/pull/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:export_header.bzl", "generate_dummy_export_header")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 generate_dummy_export_header(
     name = "export_header",


### PR DESCRIPTION
Update dependencies and add proper `load` statements to be Bazel 9 compliant.